### PR TITLE
 cookie can now handle more than 1 value being set

### DIFF
--- a/tornado_utils/http_test_client.py
+++ b/tornado_utils/http_test_client.py
@@ -74,8 +74,12 @@ class TestClient(HTTPClientMixin):
     def _update_cookies(self, headers):
         try:
             sc = headers['Set-Cookie']
-            self.cookies.update(Cookie.SimpleCookie(
-              escape.native_str(sc)))
+            cookies = escape.native_str(sc)
+            while True:
+                self.cookies.update(Cookie.SimpleCookie(cookies))
+                if cookies.find(',') == -1:
+                    break;
+                cookies = cookies[cookies.find(',') + len(',') :]
         except KeyError:
             return
 

--- a/tornado_utils/http_test_client.py
+++ b/tornado_utils/http_test_client.py
@@ -70,7 +70,6 @@ class TestClient(HTTPClientMixin):
         self._update_cookies(response.headers)
         return response
 
-
     def _update_cookies(self, headers):
         try:
             sc = headers['Set-Cookie']
@@ -78,8 +77,8 @@ class TestClient(HTTPClientMixin):
             while True:
                 self.cookies.update(Cookie.SimpleCookie(cookies))
                 if cookies.find(',') == -1:
-                    break;
-                cookies = cookies[cookies.find(',') + len(',') :]
+                    break
+                cookies = cookies[cookies.find(',') + len(','):]
         except KeyError:
             return
 

--- a/tornado_utils/http_test_client.py
+++ b/tornado_utils/http_test_client.py
@@ -70,6 +70,7 @@ class TestClient(HTTPClientMixin):
         self._update_cookies(response.headers)
         return response
 
+
     def _update_cookies(self, headers):
         try:
             sc = headers['Set-Cookie']


### PR DESCRIPTION
This pull is including a commit you made 3 months ago. I don't know why it would do that. I didn't know this repo existed until a week ago let alone 3 months ago.

This commit is to fix this behaviour:
I have the below code in my app but it doesn't work without the patch as the test framework only remembers 1 cookie. This is seen in python 2.7 with Tornado 2.2.

(In a tornado handler):
handler.set_secure_cookie('user_details_id', 'i like bananas')
handler.set_secure_cookie('user', 'andy')

According to the source Cookie extends dict so I assume that makes 'update()' behave like adding a new entry to a hash and therefore multiple update() calls are fine.
http://hg.python.org/cpython/file/2.7/Lib/Cookie.py

Let me know if you think this is ok. & If it merges correctly this time
